### PR TITLE
m_DataUnpacked must be initialized to some value

### DIFF
--- a/osmpbf/dataindex.cpp
+++ b/osmpbf/dataindex.cpp
@@ -35,6 +35,7 @@ DenseNodesData::DenseNodesData(const DenseNodesData & other) : m_Group(other.m_G
 
 DenseNodesData::DenseNodesData(crosby::binary::PrimitiveGroup * denseNodesGroup, bool unpack)
 	: m_Group(denseNodesGroup)
+	, m_DataUnpacked(false)
 {
 	if (unpack)
 		unpackData();

--- a/osmpbf/include/osmpbf/dataindex.h
+++ b/osmpbf/include/osmpbf/dataindex.h
@@ -57,7 +57,7 @@ private:
 
 	crosby::binary::PrimitiveGroup * m_Group;
 	std::vector<int> m_KeyValIndex;
-	bool m_DataUnpacked;
+	bool m_DataUnpacked = false;
 };
 
 typedef std::vector<crosby::binary::PrimitiveGroup *> PrimitiveGroupVector;


### PR DESCRIPTION
When the constructor [`DenseNodesData::DenseNodesData()`](https://github.com/inphos42/osmpbf/blob/a21818fbbefd98ebcfc6c4ed545d40cd2af85453/osmpbf/dataindex.cpp#L36) it called, the field `m_DataUnpacked` might be set to true or false. If the `unpack` parameter is true in the constructor, when `DenseNodesData::unpackData()` is called, then variable `m_DataUnpacked` might be true, but the data might not actually be unpacked. This causes corruption when reading files.

This PR fixed a problem caused by the fact that m_DataUnpacked is not initilized properly.
